### PR TITLE
Initialize React frontend and Express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+frontend/node_modules/
+backend/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-README.md
+# Food Truck Ratings App
 
+This project contains a simple Express backend and a React frontend created with Vite.
+
+If you have npm v7 or later, you can install both projects at once using workspaces:
+
+```
+npm install
+```
+
+Then you can run the backend or frontend with these shortcuts:
+
+```
+npm run start:backend
+npm run dev:frontend
+```
+
+
+## Prerequisites
+
+- Node.js 18 or later
+
+## Backend
+
+```
+cd backend
+npm install
+npm start
+```
+
+The backend runs on port **3001** by default and exposes `/api/health` which returns `{ "status": "ok" }`.
+
+## Frontend
+
+```
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend uses Vite and serves the React app on port **5173** by default. Open the printed local URL in your browser to view the homepage.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Food Truck Reviews</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Food Truck Reviews</h1>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "food-truck-ratings-app",
+  "private": true,
+  "workspaces": ["backend", "frontend"],
+  "scripts": {
+    "start:backend": "npm --workspace backend start",
+    "dev:frontend": "npm --workspace frontend run dev"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold backend with Express and `/api/health`
- scaffold frontend with React via Vite
- add ignore rules for node modules
- document how to run backend and frontend
- document workspace commands for npm

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `node backend/index.js` *(fails: Cannot find module 'express')*
- `npm run dev --workspace frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497fe51a84832dba708a968eabc42b