### PR TITLE
Add staffing planner UI and integrate navigation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const fs = require('fs');
 const path = require('path');
+const cors = require('cors');
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -51,14 +52,16 @@ function computeStats(reviews) {
     } else {
       const base = stars === 0 ? 0 : thresholds[stars - 1];
       const next = thresholds[stars];
-      const progress = (score - base) / (next - base);
+      const progress = next ? (score - base) / (next - base) : 1;
       map[name] = { stars, progress: Number(progress.toFixed(2)) };
     }
   }
   return map;
 }
 
+app.use(cors());
 app.use(express.json());
+app.use('/uploads', express.static(uploadsDir));
 
 const reviews = [];
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-stew8z-codex/set-up-full-stack-project-scaffold
+    "cors": "^2.8.5",
     "express": "^4.18.2",
-    "multer": "^1.4.5"
-    "express": "^4.18.2" main
+    "multer": "^1.4.5-lts.1"
   },
   "scripts": {
     "start": "node index.js"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,580 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1e293b, #0f172a 55%);
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app__header {
+  text-align: center;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.app__header h1 {
+  font-size: 2.5rem;
+  margin: 0;
+}
+
+.app__header p {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.app__layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px rgba(15, 15, 40, 0.35);
+  backdrop-filter: blur(18px);
+}
+
+.panel--wide {
+  grid-column: 1 / -1;
+}
+
+.app__nav {
+  margin-top: 1rem;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.app__nav-button {
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.app__nav-button:hover,
+.app__nav-button:focus-visible {
+  border-color: rgba(125, 211, 252, 0.7);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.15);
+}
+
+.app__nav-button--active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.8), rgba(147, 51, 234, 0.8));
+  border-color: transparent;
+}
+
+.review-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.review-form__field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.review-form__field span {
+  color: #cbd5f5;
+}
+
+.review-form input,
+.review-form textarea,
+.review-form button {
+  font: inherit;
+}
+
+.review-form input,
+.review-form textarea {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.review-form input:focus,
+.review-form textarea:focus {
+  outline: 2px solid rgba(125, 211, 252, 0.7);
+}
+
+.review-form button {
+  margin-top: 0.5rem;
+  padding: 0.7rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.review-form button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.review-form button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px rgba(99, 102, 241, 0.35);
+}
+
+.schedule-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1100px) {
+  .schedule-grid {
+    grid-template-columns: 1.1fr 1fr;
+  }
+}
+
+.schedule-panel {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px rgba(15, 15, 40, 0.35);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.schedule-panel__header h2 {
+  margin: 0;
+}
+
+.schedule-panel__header p {
+  margin: 0.25rem 0 0;
+  color: #cbd5f5;
+}
+
+.staff-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.staff-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.65);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.staff-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.staff-card__header h3 {
+  margin: 0 0 0.25rem;
+}
+
+.staff-card__meta {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.staff-card__rest label {
+  font-size: 0.85rem;
+  display: grid;
+  gap: 0.35rem;
+  color: #cbd5f5;
+}
+
+.staff-card__rest input {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.availability-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .availability-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+}
+
+.availability-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.65rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.availability-card h4 {
+  margin: 0;
+}
+
+.availability-card label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.availability-card select,
+.availability-card input {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.availability-card__times {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.inline-form {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.85rem;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.inline-form h3 {
+  margin: 0;
+}
+
+.inline-form label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}
+
+.inline-form input,
+.inline-form select,
+.inline-form button {
+  font: inherit;
+}
+
+.inline-form input,
+.inline-form select {
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.inline-form button {
+  justify-self: flex-start;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.inline-form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px rgba(99, 102, 241, 0.35);
+}
+
+.inline-form__row {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .inline-form__row {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+.shift-columns {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 900px) {
+  .shift-columns {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}
+
+.shift-column h3 {
+  margin: 0 0 0.5rem;
+}
+
+.shift-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.shift-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.shift-card__header h4 {
+  margin: 0;
+}
+
+.shift-card__time {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.shift-card__detail {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.assignment {
+  margin: 0;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+.assignment__label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.assignment__name {
+  font-weight: 600;
+}
+
+.assignment button {
+  justify-self: flex-end;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(248, 113, 113, 0.85);
+  color: white;
+  cursor: pointer;
+}
+
+.assignment--open {
+  color: #fbbf24;
+  font-weight: 600;
+}
+
+.eligibility h5 {
+  margin: 0.5rem 0 0.35rem;
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}
+
+.eligibility ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.eligibility button {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.4);
+  background: rgba(59, 130, 246, 0.2);
+  color: #e0f2fe;
+  cursor: pointer;
+  font: inherit;
+}
+
+.eligibility__issues {
+  list-style: disc;
+  margin: 0.35rem 0 0 1.2rem;
+  color: #fca5a5;
+  font-size: 0.85rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.eligibility__warnings {
+  list-style: disc;
+  margin: 0.35rem 0 0 1.2rem;
+  color: #fcd34d;
+  font-size: 0.8rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.message {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.message--error {
+  background: rgba(239, 68, 68, 0.16);
+  color: #fecaca;
+}
+
+.message--success {
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+}
+
+.empty {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.truck-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.truck-list__item {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.truck-list__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.truck-list__header h3 {
+  margin: 0;
+}
+
+.truck-list__stars {
+  font-size: 1.25rem;
+  letter-spacing: 0.25rem;
+  color: #facc15;
+}
+
+.truck-list__progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.truck-list__progress-bar {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.truck-list__progress-value {
+  height: 100%;
+  background: linear-gradient(135deg, #f97316, #facc15);
+}
+
+.review-list {
+  list-style: none;
+  display: grid;
+  gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.review-card {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 280px) 1fr;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.review-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.review-card__content {
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.review-card__content h3 {
+  margin: 0;
+}
+
+.review-card__rating {
+  color: #38bdf8;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .review-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,250 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import SchedulePlanner from './SchedulePlanner';
+import './App.css';
+
+const initialForm = {
+  truck: '',
+  rating: '10',
+  comment: '',
+  photo: null
+};
+
+function formatStars(count) {
+  const full = '★'.repeat(count);
+  const empty = '☆'.repeat(5 - count);
+  return `${full}${empty}`;
+}
 
 export default function App() {
+  const [reviews, setReviews] = useState([]);
+  const [truckStats, setTruckStats] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState(initialForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [submitSuccess, setSubmitSuccess] = useState('');
+  const [activeView, setActiveView] = useState('schedule');
+
+  const sortedReviews = useMemo(() => {
+    return [...reviews].sort((a, b) => b.id - a.id);
+  }, [reviews]);
+
+  const loadReviews = async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const response = await fetch('/api/reviews');
+      if (!response.ok) {
+        throw new Error('Failed to load reviews');
+      }
+      const data = await response.json();
+      setReviews(data.reviews || []);
+      setTruckStats(data.trucks || {});
+    } catch (err) {
+      setError(err.message || 'Unable to load reviews.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadReviews();
+  }, []);
+
+  const handleChange = (event) => {
+    const { name, value, files } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: name === 'photo' ? (files && files[0] ? files[0] : null) : value
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!form.photo) {
+      setSubmitError('Please attach a photo of the food truck.');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError('');
+    setSubmitSuccess('');
+    try {
+      const payload = new FormData();
+      payload.append('truck', form.truck.trim());
+      payload.append('rating', form.rating);
+      payload.append('comment', form.comment.trim());
+      payload.append('photo', form.photo);
+
+      const response = await fetch('/api/reviews', {
+        method: 'POST',
+        body: payload
+      });
+
+      if (!response.ok) {
+        const info = await response.json().catch(() => ({}));
+        throw new Error(info.error || 'Unable to save review.');
+      }
+
+      await loadReviews();
+      setForm(initialForm);
+      setSubmitSuccess('Review submitted successfully!');
+    } catch (err) {
+      setSubmitError(err.message || 'Unable to submit review.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const truckEntries = Object.entries(truckStats);
+
   return (
-    <div>
-      <h1>Food Truck Reviews</h1>
+    <div className="app">
+      <header className="app__header">
+        <h1>Food Truck Operations Hub</h1>
+        <p>Plan shifts that respect legal rest rules and training needs while collecting guest feedback.</p>
+        <nav className="app__nav" aria-label="Primary">
+          <button
+            type="button"
+            className={activeView === 'schedule' ? 'app__nav-button app__nav-button--active' : 'app__nav-button'}
+            onClick={() => setActiveView('schedule')}
+          >
+            Weekly staffing planner
+          </button>
+          <button
+            type="button"
+            className={activeView === 'reviews' ? 'app__nav-button app__nav-button--active' : 'app__nav-button'}
+            onClick={() => setActiveView('reviews')}
+          >
+            Customer reviews
+          </button>
+        </nav>
+      </header>
+
+      {activeView === 'schedule' ? (
+        <SchedulePlanner />
+      ) : (
+        <>
+          <main className="app__layout">
+            <section className="panel">
+              <h2>Submit a Review</h2>
+              <form className="review-form" onSubmit={handleSubmit}>
+            <label className="review-form__field">
+              <span>Truck name</span>
+              <input
+                type="text"
+                name="truck"
+                value={form.truck}
+                onChange={handleChange}
+                placeholder="e.g. Tasty Tacos"
+                required
+              />
+            </label>
+
+            <label className="review-form__field">
+              <span>Rating (1-10)</span>
+              <input
+                type="number"
+                name="rating"
+                value={form.rating}
+                min="1"
+                max="10"
+                onChange={handleChange}
+                required
+              />
+            </label>
+
+            <label className="review-form__field">
+              <span>Comment</span>
+              <textarea
+                name="comment"
+                value={form.comment}
+                onChange={handleChange}
+                placeholder="What made it memorable?"
+                rows={4}
+                required
+              />
+            </label>
+
+            <label className="review-form__field">
+              <span>Upload a photo</span>
+              <input
+                type="file"
+                name="photo"
+                accept="image/*"
+                onChange={handleChange}
+                required
+              />
+            </label>
+
+            {submitError && <p className="message message--error">{submitError}</p>}
+            {submitSuccess && <p className="message message--success">{submitSuccess}</p>}
+
+            <button type="submit" disabled={submitting}>
+              {submitting ? 'Submitting…' : 'Submit review'}
+            </button>
+          </form>
+        </section>
+
+        <section className="panel">
+          <h2>Truck Progress</h2>
+          {truckEntries.length === 0 ? (
+            <p className="empty">No progress yet. Submit a perfect review to get started!</p>
+          ) : (
+            <ul className="truck-list">
+              {truckEntries.map(([name, stats]) => (
+                <li key={name} className="truck-list__item">
+                  <div className="truck-list__header">
+                    <h3>{name}</h3>
+                    <span className="truck-list__stars" aria-label={`${stats.stars} out of 5 stars`}>
+                      {formatStars(stats.stars)}
+                    </span>
+                  </div>
+                  <div className="truck-list__progress">
+                    <div className="truck-list__progress-bar">
+                      <div
+                        className="truck-list__progress-value"
+                        style={{ width: `${Math.round((stats.progress || 0) * 100)}%` }}
+                      />
+                    </div>
+                    <span>{Math.round((stats.progress || 0) * 100)}% toward the next star</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+            </section>
+          </main>
+
+          <section className="panel panel--wide">
+            <h2>Recent Reviews</h2>
+            {loading ? (
+              <p className="empty">Loading reviews…</p>
+            ) : error ? (
+              <p className="message message--error">{error}</p>
+            ) : sortedReviews.length === 0 ? (
+              <p className="empty">No reviews yet. Be the first to share your thoughts!</p>
+            ) : (
+              <ul className="review-list">
+                {sortedReviews.map((review) => (
+                  <li key={review.id} className="review-card">
+                    <div className="review-card__image">
+                      <img src={`/uploads/${review.photo}`} alt={`${review.truck} food truck`} />
+                    </div>
+                    <div className="review-card__content">
+                      <header>
+                        <h3>{review.truck}</h3>
+                        <span className="review-card__rating">Rating: {review.rating}/10</span>
+                      </header>
+                      <p>{review.comment}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/SchedulePlanner.jsx
+++ b/frontend/src/SchedulePlanner.jsx
@@ -1,0 +1,622 @@
+import React, { useMemo, useState } from 'react';
+
+const weekDays = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday'
+];
+
+function createAvailabilityTemplate() {
+  return weekDays.reduce((acc, day) => {
+    acc[day] = {
+      status: 'Available',
+      start: '09:00',
+      end: '17:00',
+      notes: ''
+    };
+    return acc;
+  }, {});
+}
+
+const defaultStaff = [
+  {
+    id: 'staff-1',
+    name: 'Alex Johnson',
+    roles: ['Manager', 'Supervisor'],
+    trainings: ['Food Safety Level 2', 'First Aid'],
+    restHours: 11,
+    availability: {
+      ...createAvailabilityTemplate(),
+      Wednesday: { status: 'Partial - University', start: '13:00', end: '21:00', notes: 'Morning lectures' },
+      Saturday: { status: 'Available', start: '10:00', end: '18:00', notes: '' },
+      Sunday: { status: 'Holiday', start: '00:00', end: '00:00', notes: 'Family day' }
+    }
+  },
+  {
+    id: 'staff-2',
+    name: 'Priya Singh',
+    roles: ['Barista', 'Cashier'],
+    trainings: ['Barista Certification', 'Allergen Awareness'],
+    restHours: 12,
+    availability: {
+      ...createAvailabilityTemplate(),
+      Monday: { status: 'Maternity/Paternity', start: '00:00', end: '00:00', notes: 'Leave until June' },
+      Tuesday: { status: 'Maternity/Paternity', start: '00:00', end: '00:00', notes: '' },
+      Wednesday: { status: 'Maternity/Paternity', start: '00:00', end: '00:00', notes: '' }
+    }
+  },
+  {
+    id: 'staff-3',
+    name: 'Diego Ramirez',
+    roles: ['Chef'],
+    trainings: ['Food Safety Level 3', 'Knife Skills'],
+    restHours: 10,
+    availability: {
+      ...createAvailabilityTemplate(),
+      Thursday: { status: 'Unavailable', start: '00:00', end: '00:00', notes: 'Holiday travel' },
+      Friday: { status: 'Unavailable', start: '00:00', end: '00:00', notes: 'Holiday travel' }
+    }
+  }
+];
+
+const defaultShifts = [
+  {
+    id: 'shift-1',
+    day: 'Monday',
+    role: 'Manager',
+    start: '08:00',
+    end: '16:00',
+    requiredTraining: 'First Aid',
+    notes: 'Open truck and supervise setup',
+    assignedStaffId: ''
+  },
+  {
+    id: 'shift-2',
+    day: 'Wednesday',
+    role: 'Chef',
+    start: '11:00',
+    end: '19:00',
+    requiredTraining: 'Food Safety Level 3',
+    notes: 'Prep and service for lunch/dinner',
+    assignedStaffId: ''
+  },
+  {
+    id: 'shift-3',
+    day: 'Saturday',
+    role: 'Barista',
+    start: '09:00',
+    end: '15:00',
+    requiredTraining: 'Barista Certification',
+    notes: 'Coffee cart at farmers market',
+    assignedStaffId: ''
+  }
+];
+
+function timeToMinutes(value) {
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+function dayIndex(day) {
+  const index = weekDays.indexOf(day);
+  return index === -1 ? 0 : index;
+}
+
+function minutesFromWeekStart(day, time) {
+  return dayIndex(day) * 24 * 60 + timeToMinutes(time);
+}
+
+function checkRestCompliance(staff, shift, shifts) {
+  const restMinutes = (staff.restHours || 0) * 60;
+  if (!restMinutes) {
+    return { ok: true };
+  }
+
+  const targetStart = minutesFromWeekStart(shift.day, shift.start);
+  const targetEnd = minutesFromWeekStart(shift.day, shift.end);
+
+  const assignedShifts = shifts.filter((item) => item.assignedStaffId === staff.id && item.id !== shift.id);
+
+  for (const other of assignedShifts) {
+    const otherStart = minutesFromWeekStart(other.day, other.start);
+    const otherEnd = minutesFromWeekStart(other.day, other.end);
+
+    if (
+      (targetStart >= otherStart && targetStart < otherEnd) ||
+      (targetEnd > otherStart && targetEnd <= otherEnd) ||
+      (otherStart >= targetStart && otherStart < targetEnd)
+    ) {
+      return { ok: false, reason: 'Overlaps with another assigned shift.' };
+    }
+
+    if (otherEnd <= targetStart) {
+      const gap = targetStart - otherEnd;
+      if (gap < restMinutes) {
+        const needed = Math.ceil((restMinutes - gap) / 60);
+        return { ok: false, reason: `Needs ${needed} more hour(s) rest after previous shift.` };
+      }
+    }
+
+    if (targetEnd <= otherStart) {
+      const gap = otherStart - targetEnd;
+      if (gap < restMinutes) {
+        const needed = Math.ceil((restMinutes - gap) / 60);
+        return { ok: false, reason: `Requires ${needed} more hour(s) rest before next shift.` };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+function evaluateStaffForShift(staff, shift, shifts) {
+  const issues = [];
+  const warnings = [];
+
+  if (shift.role && !staff.roles.includes(shift.role)) {
+    issues.push('Role not in skill set.');
+  }
+
+  if (shift.requiredTraining && !staff.trainings.includes(shift.requiredTraining)) {
+    issues.push('Missing required training.');
+  }
+
+  const dailyAvailability = staff.availability[shift.day];
+  if (!dailyAvailability) {
+    issues.push('No availability recorded.');
+  } else {
+    const status = dailyAvailability.status;
+    if (status === 'Holiday') {
+      issues.push('On holiday.');
+    } else if (status === 'Maternity/Paternity') {
+      issues.push('On maternity/paternity leave.');
+    } else if (status === 'Unavailable') {
+      issues.push('Marked unavailable.');
+    } else {
+      const availableStart = timeToMinutes(dailyAvailability.start);
+      const availableEnd = timeToMinutes(dailyAvailability.end);
+      const shiftStart = timeToMinutes(shift.start);
+      const shiftEnd = timeToMinutes(shift.end);
+
+      if (shiftStart < availableStart || shiftEnd > availableEnd) {
+        issues.push('Shift is outside availability.');
+      }
+
+      if (status === 'Partial - University') {
+        warnings.push('Availability reduced due to university.');
+      }
+    }
+  }
+
+  const rest = checkRestCompliance(staff, shift, shifts);
+  if (!rest.ok) {
+    issues.push(rest.reason);
+  }
+
+  return {
+    eligible: issues.length === 0,
+    issues,
+    warnings
+  };
+}
+
+function generateId(prefix) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export default function SchedulePlanner() {
+  const [staffMembers, setStaffMembers] = useState(defaultStaff);
+  const [shifts, setShifts] = useState(defaultShifts);
+  const [newStaff, setNewStaff] = useState({
+    name: '',
+    roles: '',
+    trainings: '',
+    restHours: 11
+  });
+  const [newShift, setNewShift] = useState({
+    day: 'Monday',
+    role: '',
+    start: '09:00',
+    end: '17:00',
+    requiredTraining: '',
+    notes: ''
+  });
+
+  const groupedShifts = useMemo(() => {
+    return weekDays.map((day) => ({
+      day,
+      items: shifts.filter((shift) => shift.day === day)
+    }));
+  }, [shifts]);
+
+  const handleStaffFieldChange = (staffId, field, value) => {
+    setStaffMembers((prev) =>
+      prev.map((staff) => (staff.id === staffId ? { ...staff, [field]: value } : staff))
+    );
+  };
+
+  const handleAvailabilityChange = (staffId, day, changes) => {
+    setStaffMembers((prev) =>
+      prev.map((staff) => {
+        if (staff.id !== staffId) return staff;
+        return {
+          ...staff,
+          availability: {
+            ...staff.availability,
+            [day]: {
+              ...staff.availability[day],
+              ...changes
+            }
+          }
+        };
+      })
+    );
+  };
+
+  const handleAddStaff = (event) => {
+    event.preventDefault();
+    if (!newStaff.name.trim()) {
+      return;
+    }
+
+    const staffRecord = {
+      id: generateId('staff'),
+      name: newStaff.name.trim(),
+      roles: newStaff.roles
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean),
+      trainings: newStaff.trainings
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean),
+      restHours: Number(newStaff.restHours) || 0,
+      availability: createAvailabilityTemplate()
+    };
+
+    setStaffMembers((prev) => [...prev, staffRecord]);
+    setNewStaff({ name: '', roles: '', trainings: '', restHours: 11 });
+  };
+
+  const handleAddShift = (event) => {
+    event.preventDefault();
+    if (!newShift.role.trim()) {
+      return;
+    }
+
+    const shift = {
+      ...newShift,
+      id: generateId('shift'),
+      role: newShift.role.trim(),
+      requiredTraining: newShift.requiredTraining.trim(),
+      assignedStaffId: ''
+    };
+
+    setShifts((prev) => [...prev, shift]);
+    setNewShift({ day: 'Monday', role: '', start: '09:00', end: '17:00', requiredTraining: '', notes: '' });
+  };
+
+  const assignStaffToShift = (shiftId, staffId) => {
+    setShifts((prev) =>
+      prev.map((shift) => {
+        if (shift.id !== shiftId) return shift;
+        const staff = staffMembers.find((item) => item.id === staffId);
+        const evaluation = staff ? evaluateStaffForShift(staff, shift, prev) : { eligible: false };
+        if (!staff || !evaluation.eligible) {
+          return shift;
+        }
+        return { ...shift, assignedStaffId: staffId };
+      })
+    );
+  };
+
+  const unassignShift = (shiftId) => {
+    setShifts((prev) => prev.map((shift) => (shift.id === shiftId ? { ...shift, assignedStaffId: '' } : shift)));
+  };
+
+  const getEligibilitySummary = (shift) => {
+    return staffMembers.map((staff) => {
+      const evaluation = evaluateStaffForShift(staff, shift, shifts);
+      return { staff, evaluation };
+    });
+  };
+
+  return (
+    <div className="schedule-grid">
+      <section className="schedule-panel">
+        <header className="schedule-panel__header">
+          <h2>Team availability</h2>
+          <p>Track legal rest periods, leave and training readiness before planning shifts.</p>
+        </header>
+
+        <div className="staff-list">
+          {staffMembers.map((staff) => (
+            <article key={staff.id} className="staff-card">
+              <header className="staff-card__header">
+                <div>
+                  <h3>{staff.name}</h3>
+                  <p className="staff-card__meta">Roles: {staff.roles.length ? staff.roles.join(', ') : '—'}</p>
+                  <p className="staff-card__meta">Training: {staff.trainings.length ? staff.trainings.join(', ') : '—'}</p>
+                </div>
+                <div className="staff-card__rest">
+                  <label>
+                    Rest requirement (hrs)
+                    <input
+                      type="number"
+                      min="0"
+                      value={staff.restHours}
+                      onChange={(event) => handleStaffFieldChange(staff.id, 'restHours', Number(event.target.value))}
+                    />
+                  </label>
+                </div>
+              </header>
+
+              <div className="availability-grid">
+                {weekDays.map((day) => {
+                  const availability = staff.availability[day] || { status: 'Available', start: '09:00', end: '17:00', notes: '' };
+                  return (
+                    <div key={day} className="availability-card">
+                      <h4>{day}</h4>
+                      <label>
+                        Status
+                        <select
+                          value={availability.status}
+                          onChange={(event) =>
+                            handleAvailabilityChange(staff.id, day, { status: event.target.value })
+                          }
+                        >
+                          <option value="Available">Available</option>
+                          <option value="Partial - University">Partial - University</option>
+                          <option value="Unavailable">Unavailable</option>
+                          <option value="Holiday">Holiday</option>
+                          <option value="Maternity/Paternity">Maternity/Paternity</option>
+                        </select>
+                      </label>
+                      {(availability.status === 'Available' || availability.status === 'Partial - University') && (
+                        <div className="availability-card__times">
+                          <label>
+                            From
+                            <input
+                              type="time"
+                              value={availability.start}
+                              onChange={(event) =>
+                                handleAvailabilityChange(staff.id, day, { start: event.target.value })
+                              }
+                            />
+                          </label>
+                          <label>
+                            To
+                            <input
+                              type="time"
+                              value={availability.end}
+                              onChange={(event) =>
+                                handleAvailabilityChange(staff.id, day, { end: event.target.value })
+                              }
+                            />
+                          </label>
+                        </div>
+                      )}
+                      <label>
+                        Notes
+                        <input
+                          type="text"
+                          value={availability.notes}
+                          onChange={(event) =>
+                            handleAvailabilityChange(staff.id, day, { notes: event.target.value })
+                          }
+                          placeholder="e.g. covering university lecture"
+                        />
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <form className="inline-form" onSubmit={handleAddStaff}>
+          <h3>Add team member</h3>
+          <div className="inline-form__row">
+            <label>
+              Name
+              <input
+                type="text"
+                value={newStaff.name}
+                onChange={(event) => setNewStaff((prev) => ({ ...prev, name: event.target.value }))}
+                required
+              />
+            </label>
+            <label>
+              Rest hours
+              <input
+                type="number"
+                min="0"
+                value={newStaff.restHours}
+                onChange={(event) => setNewStaff((prev) => ({ ...prev, restHours: event.target.value }))}
+              />
+            </label>
+          </div>
+          <label>
+            Roles (comma separated)
+            <input
+              type="text"
+              value={newStaff.roles}
+              onChange={(event) => setNewStaff((prev) => ({ ...prev, roles: event.target.value }))}
+              placeholder="Chef, Barista"
+            />
+          </label>
+          <label>
+            Training & qualifications (comma separated)
+            <input
+              type="text"
+              value={newStaff.trainings}
+              onChange={(event) => setNewStaff((prev) => ({ ...prev, trainings: event.target.value }))}
+              placeholder="Food Safety Level 2"
+            />
+          </label>
+          <button type="submit">Add team member</button>
+        </form>
+      </section>
+
+      <section className="schedule-panel">
+        <header className="schedule-panel__header">
+          <h2>Weekly shift planner</h2>
+          <p>See who matches each role, confirm rest breaks and assign confidently.</p>
+        </header>
+
+        <form className="inline-form" onSubmit={handleAddShift}>
+          <h3>Create shift</h3>
+          <div className="inline-form__row">
+            <label>
+              Day
+              <select
+                value={newShift.day}
+                onChange={(event) => setNewShift((prev) => ({ ...prev, day: event.target.value }))}
+              >
+                {weekDays.map((day) => (
+                  <option key={day} value={day}>
+                    {day}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Role
+              <input
+                type="text"
+                value={newShift.role}
+                onChange={(event) => setNewShift((prev) => ({ ...prev, role: event.target.value }))}
+                required
+              />
+            </label>
+          </div>
+          <div className="inline-form__row">
+            <label>
+              From
+              <input
+                type="time"
+                value={newShift.start}
+                onChange={(event) => setNewShift((prev) => ({ ...prev, start: event.target.value }))}
+              />
+            </label>
+            <label>
+              To
+              <input
+                type="time"
+                value={newShift.end}
+                onChange={(event) => setNewShift((prev) => ({ ...prev, end: event.target.value }))}
+              />
+            </label>
+            <label>
+              Required training
+              <input
+                type="text"
+                value={newShift.requiredTraining}
+                onChange={(event) =>
+                  setNewShift((prev) => ({ ...prev, requiredTraining: event.target.value }))
+                }
+                placeholder="Optional"
+              />
+            </label>
+          </div>
+          <label>
+            Notes
+            <input
+              type="text"
+              value={newShift.notes}
+              onChange={(event) => setNewShift((prev) => ({ ...prev, notes: event.target.value }))}
+              placeholder="e.g. lunch rush support"
+            />
+          </label>
+          <button type="submit">Add shift</button>
+        </form>
+
+        <div className="shift-columns">
+          {groupedShifts.map(({ day, items }) => (
+            <div key={day} className="shift-column">
+              <h3>{day}</h3>
+              {items.length === 0 ? (
+                <p className="empty">No shifts planned yet.</p>
+              ) : (
+                items.map((shift) => {
+                  const summary = getEligibilitySummary(shift);
+                  const assigned = staffMembers.find((staff) => staff.id === shift.assignedStaffId);
+                  return (
+                    <article key={shift.id} className="shift-card">
+                      <header className="shift-card__header">
+                        <div>
+                          <h4>{shift.role}</h4>
+                          <p className="shift-card__time">
+                            {shift.start} – {shift.end}
+                          </p>
+                        </div>
+                        {assigned ? (
+                          <div className="assignment">
+                            <span className="assignment__label">Assigned</span>
+                            <span className="assignment__name">{assigned.name}</span>
+                            <button type="button" onClick={() => unassignShift(shift.id)}>
+                              Clear
+                            </button>
+                          </div>
+                        ) : (
+                          <p className="assignment assignment--open">Unassigned</p>
+                        )}
+                      </header>
+                      {shift.requiredTraining && (
+                        <p className="shift-card__detail">Training: {shift.requiredTraining}</p>
+                      )}
+                      {shift.notes && <p className="shift-card__detail">Notes: {shift.notes}</p>}
+
+                      <div className="eligibility">
+                        <h5>Eligible team</h5>
+                        <ul>
+                          {summary
+                            .filter(({ evaluation }) => evaluation.eligible)
+                            .map(({ staff, evaluation }) => (
+                              <li key={staff.id}>
+                                <button type="button" onClick={() => assignStaffToShift(shift.id, staff.id)}>
+                                  {staff.name}
+                                </button>
+                                {evaluation.warnings.length > 0 && (
+                                  <ul className="eligibility__warnings">
+                                    {evaluation.warnings.map((warning, index) => (
+                                      <li key={index}>{warning}</li>
+                                    ))}
+                                  </ul>
+                                )}
+                              </li>
+                            ))}
+                        </ul>
+
+                        <h5>Needs attention</h5>
+                        <ul>
+                          {summary
+                            .filter(({ evaluation }) => !evaluation.eligible)
+                            .map(({ staff, evaluation }) => (
+                              <li key={staff.id}>
+                                <span>{staff.name}</span>
+                                <ul className="eligibility__issues">
+                                  {evaluation.issues.map((issue, index) => (
+                                    <li key={index}>{issue}</li>
+                                  ))}
+                                </ul>
+                              </li>
+                            ))}
+                        </ul>
+                      </div>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+      '/uploads': 'http://localhost:3001'
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add a weekly staffing planner that tracks availability, leave, rest compliance, and training requirements for each shift
- update the app navigation so operations staff can toggle between the planner and the existing review workflow
- style the planner with cards, inline forms, and eligibility highlights for quick compliance checks

## Testing
- npm install *(fails: registry returned 403 for cors package)*

------
https://chatgpt.com/codex/tasks/task_e_68f14bd1ba78832d9556ab8cd814874e